### PR TITLE
Fixed commit link in changelog_html.mustache

### DIFF
--- a/src/main/resources/static/changelog_html.mustache
+++ b/src/main/resources/static/changelog_html.mustache
@@ -21,7 +21,7 @@ Changelog of {{projectName}}.
 
 
    {{#commits}}
-<a href="{{bitbucketUrl}}/bitbucket/projects/{{projectKey}}/repos/{{repositorySlug}}/commits/{{hash}}">{{hash}}</a> {{authorName}} <i>{{commitTime}}</i>
+<a href="{{bitbucketUrl}}/projects/{{projectKey}}/repos/{{repositorySlug}}/commits/{{hashFull}}">{{hash}}</a> {{authorName}} <i>{{commitTime}}</i>
 <h3>{{{messageTitle}}}</h3>
 <ul>
 {{#messageBodyItems}}


### PR DESCRIPTION
Generated commit link was not working due to incorrect basepath
Generated commit link was not working due to usage of shortened commitID instead of full commitID